### PR TITLE
Fix bug in LLM response popup

### DIFF
--- a/llm-text-transform/index.html
+++ b/llm-text-transform/index.html
@@ -82,6 +82,19 @@
     <!-- Toast notification container -->
     <div id="toastContainer"></div>
 
+    <!-- Response Popup Structure -->
+    <div class="response-popup-overlay" id="responsePopupOverlay">
+        <div class="response-popup" id="responsePopup">
+            <div class="response-popup-header">
+                <h3>LLM Response</h3>
+                <button class="close-popup-btn"><i class="fas fa-times"></i></button>
+            </div>
+            <div class="response-popup-content">
+                <pre class="response-content" id="responseContent"></pre>
+            </div>
+        </div>
+    </div>
+
     <!-- Import the JavaScript file -->
     <script src="transformer.js"></script>
 </body>

--- a/llm-text-transform/transformer.js
+++ b/llm-text-transform/transformer.js
@@ -14,7 +14,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // --- DOM References ---
     const newBtn = document.getElementById('newBtn');
-    const saveBtn = document.getElementById('saveBtn');
+    const saveBtn = document.getElementByElementById('saveBtn');
     const loadBtn = document.getElementById('loadBtn');
     const loadFile = document.getElementById('loadFile');
     const transformBtn = document.getElementById('transformBtn');
@@ -677,6 +677,27 @@ document.addEventListener('DOMContentLoaded', async () => {
         
         setStatus('Printing document...', 'info');
     }
+
+    // Show response popup
+    function showResponsePopup(responseText) {
+        const responsePopupOverlay = document.getElementById('responsePopupOverlay');
+        const responseContent = document.getElementById('responseContent');
+        responseContent.textContent = responseText;
+        responsePopupOverlay.style.display = 'flex';
+    }
+
+    // Close response popup
+    function closeResponsePopup() {
+        const responsePopupOverlay = document.getElementById('responsePopupOverlay');
+        responsePopupOverlay.style.display = 'none';
+    }
+
+    // Append the popup HTML structure to the body
+    const responsePopupTemplate = templates.responsePopup();
+    renderTemplate(responsePopupTemplate, document.body);
+
+    // Add event listener to close the popup when the close button is clicked
+    document.querySelector('.close-popup-btn').addEventListener('click', closeResponsePopup);
 
     // --- Event Listeners ---
     newBtn.addEventListener('click', () => {


### PR DESCRIPTION
Fixes #2

Fix the issue where clicking on the step LLM response does not show the popup by defining and implementing the `showResponsePopup` function.

* **`llm-text-transform/transformer.js`**
  - Define the `showResponsePopup` function to display the LLM response in a popup.
  - Define the `closeResponsePopup` function to close the popup.
  - Append the popup HTML structure to the body when the DOM is loaded.
  - Add an event listener to close the popup when the close button is clicked.

* **`llm-text-transform/index.html`**
  - Add a div with class `response-popup-overlay` and id `responsePopupOverlay` to the body.
  - Add a div with class `response-popup` and id `responsePopup` inside the `responsePopupOverlay`.
  - Add a div with class `response-popup-header` inside the `response-popup`.
  - Add a button with class `close-popup-btn` inside the `response-popup-header`.
  - Add a div with class `response-popup-content` inside the `response-popup`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/joelmnz/ai-slop/pull/7?shareId=8df6462c-97e4-4361-bfe8-e828e40910e0).